### PR TITLE
Broken custom version on linux

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,3 +18,13 @@ suites:
       - recipe[firefox_test::version]
       - recipe[firefox_test::x11]
     attributes:
+
+  - name: firefox_custom_version_test
+    run_list:
+      - recipe[firefox_test::default]
+    attributes: { firefox: { version: "28.0+build2-0ubuntu2" } }
+    excludes:
+      - ubuntu-12.04
+      - centos-6.5
+      - centos-7.0
+

--- a/test/integration/firefox_custom_version_test/serverspec/default_spec.rb
+++ b/test/integration/firefox_custom_version_test/serverspec/default_spec.rb
@@ -1,0 +1,11 @@
+require 'serverspec'
+
+# Required by serverspec
+set :backend, :exec
+
+describe 'firefox::default' do
+  describe command('firefox -v') do
+    its(:stdout) { should match(/Mozilla Firefox 28\.0/) }
+    its(:exit_status) { should eq 0 }
+  end
+end


### PR DESCRIPTION
First of all thanks for the great cookbook!

It look like the chef `run_action(:upgrade)` is ignoring the version.
[recipes/default.rb#L40..L41](https://github.com/tas50/Firefox/blob/master/recipes/default.rb#L40..L41)

At the moment it is not possible to install a different version than latest on ubuntu - I added a kitchen test for it.

It works if instead of `run_action(:upgrade)` a regular `action :install` is being used but that brakes the `firefox_test::version`

Could it be feasible to create a `firefox::upgrade` recipe and use that for `firefox_test::version` ?

Thanks