### PR TITLE
Mac volume path incorrect

### DIFF
--- a/.kitchen.fusion.yml
+++ b/.kitchen.fusion.yml
@@ -1,0 +1,22 @@
+# Usage: KITCHEN_YAML=.kitchen.fusion.yml kitchen list
+---
+driver:
+  name: vagrant
+  provider: vmware_fusion
+  customize:
+      memory: 2048
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: macosx-10.10
+    driver:
+      box: macosx-10.10
+
+suites:
+  - name: firefox_test
+    run_list:
+      - recipe[firefox_test::default]
+      - recipe[firefox_test::version]
+    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
-  - name: centos-6.5
+  - name: centos-6.6
   - name: centos-7.0
   - name: macosx-10.10
     driver:
@@ -31,6 +31,6 @@ suites:
     attributes: { firefox: { version: "28.0+build2-0ubuntu2" } }
     excludes:
       - ubuntu-12.04
-      - centos-6.5
+      - centos-6.6
       - centos-7.0
       - macosx-10.10

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,9 @@
 ---
 driver:
   name: vagrant
+  provider: vmware_fusion
+  customize:
+      memory: 2048
 
 provisioner:
   name: chef_solo
@@ -10,6 +13,9 @@ platforms:
   - name: ubuntu-14.04
   - name: centos-6.5
   - name: centos-7.0
+  - name: macosx-10.10
+    driver:
+      box: macosx-10.10
 
 suites:
   - name: firefox_test
@@ -27,4 +33,4 @@ suites:
       - ubuntu-12.04
       - centos-6.5
       - centos-7.0
-
+      - macosx-10.10

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,6 @@
 ---
 driver:
   name: vagrant
-#  provider: vmware_fusion
-#  customize:
-#      memory: 2048
 
 provisioner:
   name: chef_solo
@@ -13,9 +10,6 @@ platforms:
   - name: ubuntu-14.04
   - name: centos-6.6
   - name: centos-7.0
-  - name: macosx-10.10
-    driver:
-      box: macosx-10.10
 
 suites:
   - name: firefox_test
@@ -33,4 +27,3 @@ suites:
       - ubuntu-12.04
       - centos-6.6
       - centos-7.0
-      - macosx-10.10

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,9 @@
 ---
 driver:
   name: vagrant
-  provider: vmware_fusion
-  customize:
-      memory: 2048
+#  provider: vmware_fusion
+#  customize:
+#      memory: 2048
 
 provisioner:
   name: chef_solo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+* Fix mac installer
+
 ## 2.0.0
 * Add support for Mac OS X, CentOS, and Ubuntu platforms
 * Automatically determine latest Firefox package version

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf',  '~> 3.1.0' # 3.2 has performance issue with vmware fusion
-gem 'chefspec',   '~> 4.1.1'
-gem 'foodcritic', '~> 4.0.0'
-gem 'rubocop',    '~> 0.27.1'
+gem 'chefspec',   '~> 4.1'
+gem 'foodcritic', '~> 4.0'
+gem 'rubocop',    '~> 0.31'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf',  '~> 3.2.1'
+gem 'berkshelf',  '~> 3.1.0' # 3.2 has performance issue with vmware fusion
 gem 'chefspec',   '~> 4.1.1'
 gem 'foodcritic', '~> 4.0.0'
 gem 'rubocop',    '~> 0.27.1'

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -3,6 +3,7 @@ require 'openssl'
 
 # Firefox helper
 module Firefox
+  # rubocop:disable Metrics/AbcSize
   def firefox_version
     if platform_family?('windows', 'mac_os_x')
       return node['firefox']['version'] unless node['firefox']['version'] == 'latest'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs Mozilla Firefox on multiple operating systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.0.0'
+version           '2.0.1'
 
 supports 'centos'
 supports 'mac_os_x'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ if platform_family?('windows')
     action :install
   end
 elsif platform_family?('mac_os_x')
-  dmg_package 'Mozilla Firefox' do
+  dmg_package 'Firefox' do
     dmg_name 'firefox'
     source url
     action :install

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -9,7 +9,7 @@ describe 'firefox_test::default' do
     end
 
     it 'installs latest version' do
-      expect(chef_run).to install_windows_package('Mozilla Firefox 32.0.3 en-US').with(
+      expect(chef_run).to install_windows_package('Mozilla Firefox 32.0.3 (x86 en-US)').with(
         source: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/latest/win32/en-US'\
           '/Firefox%20Setup%2032.0.3.exe',
         installer_type: :custom,
@@ -27,7 +27,7 @@ describe 'firefox_test::default' do
     end
 
     it 'installs specific version and lang' do
-      expect(chef_run).to install_windows_package('Mozilla Firefox 29.0.1 fr').with(
+      expect(chef_run).to install_windows_package('Mozilla Firefox 29.0.1 (x86 fr)').with(
         source: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/29.0.1/win32/fr'\
           '/Firefox%20Setup%2029.0.1.exe',
         installer_type: :custom,

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -44,7 +44,7 @@ describe 'firefox_test::default' do
     end
 
     it 'installs latest version' do
-      expect(chef_run).to install_dmg_package('Mozilla Firefox').with(
+      expect(chef_run).to install_dmg_package('Firefox').with(
         source: 'https://download-installer.cdn.mozilla.net/pub/firefox/releases/latest/mac/en-US/Firefox%2032.0.3.dmg',
         dmg_name: 'firefox'
       )

--- a/test/fixtures/cookbooks/firefox_test/recipes/x11.rb
+++ b/test/fixtures/cookbooks/firefox_test/recipes/x11.rb
@@ -18,9 +18,9 @@
 #   (process:18177): GLib-CRITICAL **: g_slice_set_config: assertion `sys_page_size == 0' failed
 #   GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
 #
-package 'xauth'
+if platform?('ubuntu')
+  package 'xauth'
 
-# ubuntu firefox package installs .mozilla as root instead of vagrant, you can chown it or remove it completely
-execute 'chown -R vagrant:vagrant ~/.mozilla' do
-  only_if { platform?('ubuntu') }
+  # ubuntu firefox package installs .mozilla as root instead of vagrant, you can chown it or remove it completely
+  execute 'chown -R vagrant:vagrant ~/.mozilla'
 end

--- a/test/fixtures/cookbooks/firefox_test/recipes/x11.rb
+++ b/test/fixtures/cookbooks/firefox_test/recipes/x11.rb
@@ -18,9 +18,11 @@
 #   (process:18177): GLib-CRITICAL **: g_slice_set_config: assertion `sys_page_size == 0' failed
 #   GLib-GIO-Message: Using the 'memory' GSettings backend.  Your settings will not be saved or shared with other applications.
 #
-if platform?('ubuntu')
+if platform_family?('debian', 'rhel')
   package 'xauth'
 
   # ubuntu firefox package installs .mozilla as root instead of vagrant, you can chown it or remove it completely
-  execute 'chown -R vagrant:vagrant ~/.mozilla'
+  execute 'chown -R vagrant:vagrant ~/.mozilla' do
+    only_if { platform?('ubuntu') }
+  end
 end

--- a/test/integration/firefox_test/serverspec/default_spec.rb
+++ b/test/integration/firefox_test/serverspec/default_spec.rb
@@ -4,8 +4,16 @@ require 'serverspec'
 set :backend, :exec
 
 describe 'firefox::default' do
-  describe command('firefox -v') do
-    its(:stdout) { should match(/Mozilla Firefox /) }
-    its(:exit_status) { should eq 0 }
+  case os[:family]
+  when 'darwin'
+    describe command('/Applications/Firefox.app/Contents/MacOS/firefox -v') do
+      its(:stdout) { should match(/Mozilla Firefox /) }
+      its(:exit_status) { should eq 0 }
+    end
+  else
+    describe command('firefox -v') do
+      its(:stdout) { should match(/Mozilla Firefox /) }
+      its(:exit_status) { should eq 0 }
+    end
   end
 end


### PR DESCRIPTION
Mac installer would fail with the following message:
STDERR: rsync: link_stat "/Volumes/Mozilla Firefox/Mozilla Firefox.app" failed: No such file or directory