### PR TITLE
avoid re-installing on windows platform

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@ if platform_family?('windows', 'mac_os_x')
 end
 
 if platform_family?('windows')
-  windows_package "Mozilla Firefox #{version} #{node['firefox']['lang']}" do
+  windows_package "Mozilla Firefox #{version} (x86 #{node['firefox']['lang']})" do
     source url
     installer_type :custom
     options '-ms'


### PR DESCRIPTION
Change windows_package's name to the same as 'DisplayName' in registry key. 
It is required for proper idempotence.