### PR TITLE
Fix redirection forbidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ firefox Cookbook CHANGELOG
 ==========================
 This file is used to list changes made in each version of the firefox cookbook.
 
+## 2.0.5
+* Fix redirection forbidden 
+
 ## 2.0.4
 * Update platforms tested with Kitchen CI
 * Run Travis CI tests in the container infrastructure and cache bundler installs
@@ -15,7 +18,7 @@ This file is used to list changes made in each version of the firefox cookbook.
 
 ## 2.0.2
 * Fix installations on OS X
-* Fix the Windows package name in the registry to prevent installs on each r    un
+* Fix the Windows package name in the registry to prevent installs on each run
 * Add a VMware Fusion Test Kitchen file for OS X testing
 * Chefspec fixes
 * Gemfile dependencies loosened

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -26,7 +26,7 @@ module Firefox
   end
 
   def firefox_base_uri
-    "#{node['firefox']['releases_url']}/#{node['firefox']['version']}/#{firefox_platform}/#{node['firefox']['lang']}"
+    "#{node['firefox']['releases_url']}/#{node['firefox']['version']}/#{firefox_platform}/#{node['firefox']['lang']}/"
   end
 
   def firefox_latest

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'tsmith84@gmail.com'
 license 'Apache 2.0'
 description 'Installs Mozilla Firefox on multiple operating systems'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.4'
+version '2.0.5'
 
 %w(rhel centos scientific amazon oracle windows mac_os_x debian ubuntu).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 
 if platform_family?('windows', 'mac_os_x')
   version = firefox_version
-  url = "#{firefox_base_uri}/#{firefox_package(version)}"
+  url = "#{firefox_base_uri}#{firefox_package(version)}"
 end
 
 if platform_family?('windows')


### PR DESCRIPTION
Latest firefox cdn url requires a trailing slash; otherwise, it will redirect from https to http which open_uri does not allow.

        RuntimeError
         ------------
         redirection forbidden: https://download-installer.cdn.mozilla.net/pub/firefox/releases/latest/win32/en-US -> http://download-installer.cdn.mozilla.net/pub/firefox/releases/latest/win32/en-US/
